### PR TITLE
Add code coverage to continuous integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+plugins = covimerage
+data_file = .coverage_covimerage

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 test/vimtest
+profile_file*
+.coverage_covimerage
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,15 @@ sudo: required
 services:
     - docker
 language: generic
+install:
+    - pip install --user covimerage==0.1.5
 script: |
-    ./run_tests.sh
+    ./run_tests.sh --profile
+after_success: |
+    set -eo pipefail
+    profile_file=$(ls | grep 'profile_file' | sort | tail -n 1)
+    python -m covimerage write_coverage "${profile_file}"
+    sed -i "s,/testplugin/,$PWD/,g" .coverage_covimerage
+    python -m covimerage -vv xml
+    python -m covimerage report -m
+    bash <(curl -s https://codecov.io/bash) -X search -X gcov -X coveragepy -f coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 vim-lsp-ccls: vim plugin for the ccls Language Server
 ===============================================================
 [![Travis CI Build Status](https://travis-ci.org/m-pilia/vim-lsp-ccls.svg?branch=master)](https://travis-ci.org/m-pilia/vim-lsp-ccls)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/m-pilia/disptools/blob/master/LICENSE)
+[![codecov](https://codecov.io/gh/m-pilia/vim-lsp-ccls/branch/master/graph/badge.svg)](https://codecov.io/gh/m-pilia/vim-lsp-ccls/branch/master)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/m-pilia/vim-lsp-ccls/blob/master/LICENSE)
 
 This plugin supports some additional methods provided by
 [ccls](https://github.com/MaskRay/ccls), which are not part of the standard

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,6 +2,13 @@
 
 set -xeuo pipefail
 
+# Profiling file (no profiling if empty)
+profile_file=
+profile_prefix=''
+if [ $# -gt 0 ] && [ "$1" == "--profile" ]; then
+    profile_prefix='profile_file'
+fi
+
 # Using the Docker image developed for ALE
 docker_image=w0rp/ale
 docker_image_id=67896c9c2c0f
@@ -17,11 +24,19 @@ exit_status=0
 
 # Run tests
 for vim in ${vim_binaries}; do
+
+    # Collect profiling data if an output file name is provided
+    if [ "${profile_prefix}" != '' ]; then
+        profile_file="${profile_prefix}_${vim}"
+    fi
+
     find test -name '*.swp' -delete
+
     docker run \
         --rm \
         -a stderr \
         -e VADER_OUTPUT_FILE=/dev/stderr \
+        -e VIM_PROFILE_FILE="${profile_file}" \
         -v "$PWD:/testplugin" \
         -v "$PWD/test:/home"\
         -w /testplugin \

--- a/test/vimrc
+++ b/test/vimrc
@@ -10,3 +10,12 @@ filetype plugin indent on
 syntax on
 
 set nocompatible
+
+let s:profile_file = $VIM_PROFILE_FILE
+if has('profile') && !empty(s:profile_file)
+    execute 'profile start ' . s:profile_file
+    profile! file autoload/**.vim
+    profile! file ftplugin/**.vim
+    profile! file plugin/**.vim
+    profile! file syntax/**.vim
+endif


### PR DESCRIPTION
Use covimerage to generate a coverage report, and upload it to codecov.

Resolves #9