### PR TITLE
Fix a bug in get_node_id_under_cursor()

### DIFF
--- a/autoload/yggdrasil/tree.vim
+++ b/autoload/yggdrasil/tree.vim
@@ -1,7 +1,7 @@
 scriptencoding utf-8
 
 function! yggdrasil#tree#get_node_id_under_cursor() dict abort
-    let l:id = str2nr(matchstr(getline('.'), '\v\[@<=\d+\]@='))
+    let l:id = str2nr(matchstr(getline('.'), '\v\[@<=\d+(\]$)@='))
     return l:self.root.find(l:id)
 endfunction
 

--- a/test/test_tree.vader
+++ b/test/test_tree.vader
@@ -61,3 +61,49 @@ Execute(Test yggdrasil#tree#insert):
   AssertEqual 'foo', tree.root.label
   AssertEqual 'root_cb', tree.root.callback
   AssertEqual 'root_lo', tree.root.lazy_open
+
+Execute(Test yggdrasil#tree#get_node_id_under_cursor):
+  let tree = {
+    \ 'bufnr': bufnr('.'),
+    \ 'maxid': -1,
+    \ 'root': {},
+    \ 'insert': function('yggdrasil#tree#insert'),
+    \ 'render': function('yggdrasil#tree#render'),
+    \ 'get_node_id_under_cursor': function('yggdrasil#tree#get_node_id_under_cursor'),
+    \ }
+
+  let node = tree.insert('node2', v:null, v:null)
+  let node.collapsed = 0
+  let node = tree.insert('node5', v:null, v:null, 0)
+  let node.collapsed = 0
+  let node = tree.insert('node0', v:null, v:null, 0)
+  let node.collapsed = 0
+  let node = tree.insert('node9[0]', v:null, v:null, 2)
+  let node.collapsed = 0
+
+  call tree.render()
+
+  call cursor(1, 1)
+  let id = tree.get_node_id_under_cursor().id
+
+  AssertEqual 0, id
+
+  call cursor(1, 3)
+  let id = tree.get_node_id_under_cursor().id
+
+  AssertEqual 0, id
+
+  call cursor(2, 1)
+  let id = tree.get_node_id_under_cursor().id
+
+  AssertEqual 1, id
+
+  call cursor(3, 1)
+  let id = tree.get_node_id_under_cursor().id
+
+  AssertEqual 2, id
+
+  call cursor(4, 1)
+  let id = tree.get_node_id_under_cursor().id
+
+  AssertEqual 3, id


### PR DESCRIPTION
Fix a bug that allowed to return the wrong id if the label of the node
under cursor contained a number within square brackets.