### PR TITLE
Do not use after for filetype syntax

### DIFF
--- a/after/syntax/yggdrasil.vim
+++ b/after/syntax/yggdrasil.vim
@@ -1,9 +1,0 @@
-scriptencoding utf-8
-
-syntax include @cpp syntax/cpp.vim
-
-syntax match CclsAnonymousNamespace "\v\(@<=anonymous namespace\)@=" contained
-syntax match CclsLabel "\v^(\s|[▸▾])*.*( \[\d+\])@=" contains=YggdrasilMarkCollapsed,YggdrasilMarkExpanded,CclsAnonymousNamespace,@cpp
-
-highlight def link CclsAnonymousNamespace CppStructure
-highlight def link CclsLabel Identifier

--- a/autoload/ccls/lsp.vim
+++ b/autoload/ccls/lsp.vim
@@ -120,6 +120,7 @@ function! ccls#lsp#request(method, params, handler) abort
             silent set filetype=yggdrasil
             silent 0file
             silent execute 'set buftype=' . l:buftype
+            call ccls#syntax#additional()
             if filereadable(l:temp_file_name)
                 call delete(l:temp_file_name)
             endif

--- a/autoload/ccls/messages.vim
+++ b/autoload/ccls/messages.vim
@@ -128,6 +128,8 @@ function! s:make_tree(method, extra_params, data) abort
     \                       g:ccls_position,
     \                       g:ccls_orientation)
 
+    call ccls#syntax#additional()
+
     " Store additional information in the tree structure
     " to avoid having too many arguments in the callbacks
     let b:yggdrasil_tree['buffer'] = bufnr('%')

--- a/autoload/ccls/syntax.vim
+++ b/autoload/ccls/syntax.vim
@@ -1,0 +1,12 @@
+scriptencoding utf-8
+
+" Additional syntax highlighting for C and C++
+function! ccls#syntax#additional() abort
+    syntax include @cpp syntax/cpp.vim
+
+    syntax match CclsAnonymousNamespace "\v\(@<=anonymous namespace\)@=" contained
+    syntax match CclsLabel "\v^(\s|[▸▾])*.*( \[\d+\])@=" contains=YggdrasilMarkCollapsed,YggdrasilMarkExpanded,CclsAnonymousNamespace,@cpp
+
+    highlight def link CclsAnonymousNamespace CppStructure
+    highlight def link CclsLabel Identifier
+endfunction


### PR DESCRIPTION
Do not add ccls-specific syntax to after, to not interfere with other
plugins using Yggdrasil.