### PR TITLE
Add support for nvim-lsp backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ features. Currently supported LSP clients are:
 * [ALE](https://github.com/w0rp/ale)
 * [coc.nvim](https://github.com/neoclide/coc.nvim)
 * [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim)
+* [nvim-lsp](https://github.com/neovim/nvim-lsp)
 * [vim-lsc](https://github.com/natebosch/vim-lsc)
 * [vim-lsp](https://github.com/prabirshrestha/vim-lsp)
 
@@ -48,6 +49,7 @@ your LSP client to use it (example instructions in the ccls wiki):
 * [ALE](https://github.com/MaskRay/ccls/wiki/ALE)
 * [coc.nvim](https://github.com/MaskRay/ccls/wiki/coc.nvim)
 * [LanguageClient-neovim](https://github.com/MaskRay/ccls/wiki/LanguageClient-neovim)
+* [nvim-lsp](https://github.com/neovim/nvim-lsp#ccls)
 * [vim-lsc](https://github.com/MaskRay/ccls/wiki/vim-lsc)
 * [vim-lsp](https://github.com/MaskRay/ccls/wiki/vim-lsp)
 

--- a/autoload/ccls/lsp.vim
+++ b/autoload/ccls/lsp.vim
@@ -95,6 +95,11 @@ function! ccls#lsp#request(bufnr, method, params, handler) abort
         catch
             call ccls#util#warning('LSP error')
         endtry
+    elseif get(g:, 'nvim_lsp', v:false)
+        " Use nvim-lsp
+        let l:call_id = ccls#lsp#nvim_lsp#register(a:handler)
+        let l:args = [a:bufnr, a:method, a:params, l:call_id]
+        call luaeval('require("vim_ccls").request(unpack(_A))', l:args)
     else
         call ccls#util#warning('No LSP plugin found!')
     end

--- a/autoload/ccls/lsp/nvim_lsp.vim
+++ b/autoload/ccls/lsp/nvim_lsp.vim
@@ -1,0 +1,22 @@
+" Currently it is not possible to call a VimL funcref from Lua. This
+" library allows to register callback funcrefs and later call them
+" through a public function, that is accessible from Lua.
+
+let s:call_id = 0
+let s:callbacks = {}
+
+" Register a callback and return a call id
+function! ccls#lsp#nvim_lsp#register(funcref) abort
+    let s:call_id += 1
+    let s:callbacks[s:call_id] = a:funcref
+    return s:call_id
+endfunction
+
+" Call a registered callback, identified by {call_id}, with given {data}
+function! ccls#lsp#nvim_lsp#callback(call_id, data) abort
+    if has_key(s:callbacks, a:call_id)
+        call call(s:callbacks[a:call_id], [a:data])
+        call remove(s:callbacks, a:call_id)
+    endif
+endfunction
+

--- a/doc/vim-ccls.txt
+++ b/doc/vim-ccls.txt
@@ -44,6 +44,7 @@ supported LSP clients are:
 * ALE                   (https://github.com/w0rp/ale)
 * coc.nvim              (https://github.com/neoclide/coc.nvim)
 * LanguageClient-neovim (https://github.com/autozimu/LanguageClient-neovim)
+* nvim-lsp              (https://github.com/neovim/nvim-lsp)
 * vim-lsc               (https://github.com/natebosch/vim-lsc)
 * vim-lsp               (https://github.com/prabirshrestha/vim-lsp)
 
@@ -66,9 +67,10 @@ To install ccls and set up a project to use it in combination with one of the
 supported LSP clients, follow the instructions in the ccls wiki:
 * https://github.com/MaskRay/ccls/wiki/ALE
 * https://github.com/MaskRay/ccls/wiki/coc.nvim
+* https://github.com/neovim/nvim-lsp#ccls
+* https://github.com/MaskRay/ccls/wiki/LanguageClient-neovim
 * https://github.com/MaskRay/ccls/wiki/vim-lsc
 * https://github.com/MaskRay/ccls/wiki/vim-lsp
-* https://github.com/MaskRay/ccls/wiki/LanguageClient-neovim
 
 ==============================================================================
 Options                                                     *vim-ccls-options*

--- a/lua/vim_ccls/init.lua
+++ b/lua/vim_ccls/init.lua
@@ -1,0 +1,38 @@
+local function warning(message)
+    vim.api.nvim_call_function("ccls#util#warning", {"nvim-lsp error: " .. message})
+end
+
+local function get_ccls(bufnr)
+    clients = vim.lsp.buf_get_clients(bufnr)
+    for _, v in ipairs(clients) do
+        if v["name"] == "ccls" then
+            return v
+        end
+    end
+    return nil
+end
+
+local function request(bufnr, method, params, call_id)
+    ccls = get_ccls(bufnr)
+
+    if ccls == nil then
+        warning("ccls unavailable for buffer " .. bufnr)
+        return
+    end
+
+    status = ccls.request(method, params, function(_, method, result, client_id)
+        if not result then
+            warning("no result from ccls")
+        else
+            vim.api.nvim_call_function("ccls#lsp#nvim_lsp#callback", {call_id, result})
+        end
+    end)
+
+    if not status then
+        warning("failed ccls request")
+    end
+end
+
+return {
+    request = request,
+}

--- a/test/test_04_nvim_lsp.vader
+++ b/test/test_04_nvim_lsp.vader
@@ -1,0 +1,26 @@
+Before:
+  source test/utils.vim
+  source test/mock/function.vim
+
+  let mock_handler = NewFunctionMock()
+
+  let test_data = 101
+
+After:
+  unlet! mock_handler
+  unlet! test_data
+
+  unlet! call_id
+
+Execute(Test ccls#lsp#nvim_lsp#callback()):
+  let call_id = ccls#lsp#nvim_lsp#register(mock_handler.function)
+  call ccls#lsp#nvim_lsp#callback(call_id, test_data)
+
+  AssertEqual 1, mock_handler.count
+  AssertEqual 1, len(mock_handler.args[0])
+  AssertEqual test_data, mock_handler.args[0][0]
+
+  " Test that the callback is unregistered after the first call
+  call ccls#lsp#nvim_lsp#callback(call_id, test_data)
+  AssertEqual 1, mock_handler.count
+


### PR DESCRIPTION
Add support to use nvim-lsp, the native neovim LSP client, as a backend for vim-ccls.

Resolves #23 