### PR TITLE
Rename nvim-lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ features. Currently supported LSP clients are:
 * [ALE](https://github.com/w0rp/ale)
 * [coc.nvim](https://github.com/neoclide/coc.nvim)
 * [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim)
-* [nvim-lsp](https://github.com/neovim/nvim-lsp)
+* [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
 * [vim-lsc](https://github.com/natebosch/vim-lsc)
 * [vim-lsp](https://github.com/prabirshrestha/vim-lsp)
 
@@ -49,7 +49,7 @@ your LSP client to use it (example instructions in the ccls wiki):
 * [ALE](https://github.com/MaskRay/ccls/wiki/ALE)
 * [coc.nvim](https://github.com/MaskRay/ccls/wiki/coc.nvim)
 * [LanguageClient-neovim](https://github.com/MaskRay/ccls/wiki/LanguageClient-neovim)
-* [nvim-lsp](https://github.com/neovim/nvim-lsp#ccls)
+* [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig#ccls)
 * [vim-lsc](https://github.com/MaskRay/ccls/wiki/vim-lsc)
 * [vim-lsp](https://github.com/MaskRay/ccls/wiki/vim-lsp)
 

--- a/autoload/ccls/lsp.vim
+++ b/autoload/ccls/lsp.vim
@@ -95,9 +95,9 @@ function! ccls#lsp#request(bufnr, method, params, handler) abort
         catch
             call ccls#util#warning('LSP error')
         endtry
-    elseif get(g:, 'nvim_lsp', v:false)
-        " Use nvim-lsp
-        let l:call_id = ccls#lsp#nvim_lsp#register(a:handler)
+    elseif get(g:, 'lspconfig', v:false)
+        " Use nvim-lspconfig
+        let l:call_id = ccls#lsp#nvim_lspconfig#register(a:handler)
         let l:args = [a:bufnr, a:method, a:params, l:call_id]
         call luaeval('require("vim_ccls").request(unpack(_A))', l:args)
     else

--- a/autoload/ccls/lsp/nvim_lspconfig.vim
+++ b/autoload/ccls/lsp/nvim_lspconfig.vim
@@ -6,14 +6,14 @@ let s:call_id = 0
 let s:callbacks = {}
 
 " Register a callback and return a call id
-function! ccls#lsp#nvim_lsp#register(funcref) abort
+function! ccls#lsp#nvim_lspconfig#register(funcref) abort
     let s:call_id += 1
     let s:callbacks[s:call_id] = a:funcref
     return s:call_id
 endfunction
 
 " Call a registered callback, identified by {call_id}, with given {data}
-function! ccls#lsp#nvim_lsp#callback(call_id, data) abort
+function! ccls#lsp#nvim_lspconfig#callback(call_id, data) abort
     if has_key(s:callbacks, a:call_id)
         call call(s:callbacks[a:call_id], [a:data])
         call remove(s:callbacks, a:call_id)

--- a/doc/vim-ccls.txt
+++ b/doc/vim-ccls.txt
@@ -48,7 +48,7 @@ supported LSP clients are:
 * ALE                   (https://github.com/w0rp/ale)
 * coc.nvim              (https://github.com/neoclide/coc.nvim)
 * LanguageClient-neovim (https://github.com/autozimu/LanguageClient-neovim)
-* nvim-lsp              (https://github.com/neovim/nvim-lsp)
+* nvim-lspconfig        (https://github.com/neovim/nvim-lspconfig)
 * vim-lsc               (https://github.com/natebosch/vim-lsc)
 * vim-lsp               (https://github.com/prabirshrestha/vim-lsp)
 
@@ -71,7 +71,7 @@ To install ccls and set up a project to use it in combination with one of the
 supported LSP clients, follow the instructions in the ccls wiki:
 * https://github.com/MaskRay/ccls/wiki/ALE
 * https://github.com/MaskRay/ccls/wiki/coc.nvim
-* https://github.com/neovim/nvim-lsp#ccls
+* https://github.com/neovim/nvim-lspconfig#ccls
 * https://github.com/MaskRay/ccls/wiki/LanguageClient-neovim
 * https://github.com/MaskRay/ccls/wiki/vim-lsc
 * https://github.com/MaskRay/ccls/wiki/vim-lsp

--- a/lua/vim_ccls/init.lua
+++ b/lua/vim_ccls/init.lua
@@ -1,5 +1,5 @@
 local function warning(message)
-    vim.api.nvim_call_function("ccls#util#warning", {"nvim-lsp error: " .. message})
+    vim.api.nvim_call_function("ccls#util#warning", {"nvim-lspconfig error: " .. message})
 end
 
 local function get_ccls(bufnr)
@@ -24,7 +24,7 @@ local function request(bufnr, method, params, call_id)
         if not result then
             warning("no result from ccls")
         else
-            vim.api.nvim_call_function("ccls#lsp#nvim_lsp#callback", {call_id, result})
+            vim.api.nvim_call_function("ccls#lsp#nvim_lspconfig#callback", {call_id, result})
         end
     end)
 

--- a/test/test_04_nvim_lspconfig.vader
+++ b/test/test_04_nvim_lspconfig.vader
@@ -12,15 +12,15 @@ After:
 
   unlet! call_id
 
-Execute(Test ccls#lsp#nvim_lsp#callback()):
-  let call_id = ccls#lsp#nvim_lsp#register(mock_handler.function)
-  call ccls#lsp#nvim_lsp#callback(call_id, test_data)
+Execute(Test ccls#lsp#nvim_lspconfig#callback()):
+  let call_id = ccls#lsp#nvim_lspconfig#register(mock_handler.function)
+  call ccls#lsp#nvim_lspconfig#callback(call_id, test_data)
 
   AssertEqual 1, mock_handler.count
   AssertEqual 1, len(mock_handler.args[0])
   AssertEqual test_data, mock_handler.args[0][0]
 
   " Test that the callback is unregistered after the first call
-  call ccls#lsp#nvim_lsp#callback(call_id, test_data)
+  call ccls#lsp#nvim_lspconfig#callback(call_id, test_data)
   AssertEqual 1, mock_handler.count
 


### PR DESCRIPTION
The nvim-lsp plugin has recently been renamed to lspconfig. Update references in the code and documentation.

Fixes #39