### PR TITLE
Remove duplicate lines for CclsMemberHierarchy from the help file

### DIFF
--- a/doc/vim-ccls.txt
+++ b/doc/vim-ccls.txt
@@ -253,10 +253,6 @@ CclsMemberHierarchy [-float]                             *CclsMemberHierarchy*
 
 Get a tree of members for the symbol under cursor.
 
-CclsMemberHierarchy [-float]                             *CclsMemberHierarchy*
-
-Get a tree of members for the symbol under cursor.
-
 CclsMemberFunctionHierarchy [-float]             *CclsMemberFunctionHierarchy*
 
 Get a tree of function members for the symbol under cursor.


### PR DESCRIPTION
Hi, thank you for the great plugin.

I found a duplicate section in the help file. Could you merge this change if it's OK? Thank you.