### PR TITLE
Refactor URI conversion handling

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,4 +5,7 @@ coverage:
     project:
       default:
         target: 95%
+    patch:
+      default:
+        target: 80%
 

--- a/autoload/ccls/messages.vim
+++ b/autoload/ccls/messages.vim
@@ -140,7 +140,7 @@ endfunction
 
 " Produce the tree item representation for a given object.
 function! s:get_tree_item(Callback, data) dict abort
-    let l:file = matchlist(a:data.location.uri, 'file://\(.*\)')[1]
+    let l:file = ccls#uri#uri2path(a:data.location.uri)
     let l:line = str2nr(a:data.location.range.start.line) + 1
     let l:column = str2nr(a:data.location.range.start.character) + 1
     let l:tree_item = {

--- a/autoload/ccls/uri.vim
+++ b/autoload/ccls/uri.vim
@@ -1,0 +1,74 @@
+function! s:is_windows() abort
+    return has('win32') || has('win64') || has('win32unix')
+endfunction
+
+function! s:is_cygwin() abort
+    return has('win32unix')
+endfunction
+
+function! s:encode_character(c) abort
+    return printf('%%%02X', char2nr(a:c))
+endfunction
+
+function! s:encode_path(path) abort
+    let l:encoded_path = ''
+    for l:index in range(0, len(a:path) - 1)
+        if a:path[l:index] =~# '^[a-zA-Z0-9_.~/-]$'
+            let l:encoded_path .= a:path[l:index]
+        else
+            let l:encoded_path .= s:encode_character(a:path[l:index])
+        endif
+    endfor
+    return l:encoded_path
+endfunction
+
+" Convert a path to an uri
+function! ccls#uri#path2uri(path) abort
+    let l:path = a:path
+
+    if s:is_cygwin()
+        let l:path = substitute(l:path, '\c^/\([A-Z]\)/', '\U\1:/', '')
+    endif
+
+    let l:prefix = matchstr(l:path, '\v(^\w+::|^\w+://)')
+    if len(l:prefix) < 1
+        let l:prefix = 'file:///'
+    else
+        " Non-local path
+        return l:path
+    endif
+
+    let l:path = substitute(l:path, '^/', '', '')
+    let l:path = substitute(l:path, '\', '/', 'g')
+
+    let l:volume_end = s:is_windows() ? matchstrpos(l:path, '\c[A-Z]:')[2] : 0
+    if l:volume_end < 0
+        let l:volume_end = 0
+    endif
+
+    let l:volume = strpart(l:path, 0, l:volume_end)
+    let l:encoded_path = s:encode_path(l:path[l:volume_end :])
+
+    return l:prefix . l:volume . l:encoded_path
+endfunction
+
+" Convert an uri to a path
+function! ccls#uri#uri2path(uri) abort
+    let l:path = substitute(a:uri, '^file://', '', '')
+    let l:path = substitute(l:path, '[?#].*', '', '')
+    let l:path = substitute(l:path,
+    \                       '%\(\x\x\)',
+    \                       '\=printf("%c", str2nr(submatch(1), 16))',
+    \                       'g')
+    if s:is_windows()
+        if s:is_cygwin()
+            let l:path = substitute(l:path, '\c^/\([A-Z]\):/', '/\l\1/', '')
+        else
+            let l:path = substitute(l:path, '^/', '', '')
+            let l:path = substitute(l:path, '/', '\\', 'g')
+        endif
+    endif
+    return l:path
+endfunction
+
+

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -13,9 +13,11 @@ docker_image=martinopilia/vim-ccls:1
 
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
-if ! docker pull "${docker_image}" ; then
-    docker build -t "${docker_image}" .
-    docker image push docker.io/${docker_image} || echo "Docker push failed"
+if ! docker inspect --type=image "${docker_image}" >/dev/null 2>&1 ; then
+    if ! docker pull "${docker_image}" ; then
+        docker build -t "${docker_image}" .
+        docker image push docker.io/${docker_image} || echo "Docker push failed"
+    fi
 fi
 
 vim_binaries=$(docker run --rm "${docker_image}" ls /vim-build/bin \
@@ -25,7 +27,7 @@ set +e
 exit_status=0
 
 # Run tests
-for vim in ${vim_binaries}; do
+for vim in ${vim_binaries} ; do
     for test_suite in ./test/*.vader ; do
         test_name=$(basename "${test_suite}" | cut -d'.' -f1)
 

--- a/test/test_00_messages.vader
+++ b/test/test_00_messages.vader
@@ -101,38 +101,6 @@ Execute(Test plugin):
   Assert exists(':CclsCalleeHierarchy')
 
 
-Execute(Test s:path2uri):
-  let Path2uri = GetFunction(b:script, 'path2uri')
-
-  if has('win32')
-    let path = 'C:\foò\bär\file.cpp'
-    let expected = 'file://C:\fo%C3%B2\b%C3%A4r\file.cpp'
-  else
-    let path = '/foò/bär/file.cpp'
-    let expected = 'file:///fo%C3%B2/b%C3%A4r/file.cpp'
-  endif
-
-  let uri = Path2uri(path)
-
-  AssertEqual expected, uri
-
-
-Execute(Test s:uri2path):
-  let Uri2path = GetFunction(b:script, 'uri2path')
-
-  if has('win32')
-    let uri = 'file://C:\fo%C3%B2\b%C3%A4r\file.cpp'
-    let expected = 'C:\foò\bär\file.cpp'
-  else
-    let uri = 'file:///fo%C3%B2/b%C3%A4r/file.cpp'
-    let expected = '/foò/bär/file.cpp'
-  endif
-
-  let path = Uri2path(uri)
-
-  AssertEqual expected, path
-
-
 Execute(Test s:text_document_identifier):
   let Text_document_identifier = GetFunction(b:script, 'text_document_identifier')
 

--- a/test/test_00_messages.vader
+++ b/test/test_00_messages.vader
@@ -330,7 +330,7 @@ Execute(Test s:get_tree_item):
   \   'name': 'mock_name',
   \   'numChildren': 1,
   \   'location': {
-  \     'uri': 'file://mock_uri',
+  \     'uri': 'file:///fo%C3%B2/b%C3%A4r/file.cpp',
   \     'range': {
   \       'start': {
   \         'line': 20,
@@ -348,6 +348,7 @@ Execute(Test s:get_tree_item):
   AssertEqual 'success', handler_mock.args[0][0]
   AssertEqual 10, handler_mock.args[0][1].id
   AssertEqual type({->0}), type(handler_mock.args[0][1].command)
+  Assert stridx(string(handler_mock.args[0][1].command), '/foò/bär/file.cpp') >= 0, "Incorrect path"
   AssertEqual 'collapsed', handler_mock.args[0][1].collapsibleState
   AssertEqual 'mock_name', handler_mock.args[0][1].label
 

--- a/test/test_05_uri.vader
+++ b/test/test_05_uri.vader
@@ -1,0 +1,67 @@
+Before:
+  let b:script = 'autoload/ccls/uri.vim'
+
+  source test/utils.vim
+  source autoload/ccls/uri.vim
+
+
+After:
+  unlet! b:script
+
+
+Execute(Test ccls#uri#path2uri UNIX):
+  let path = '/foò/bär/file.cpp'
+  let expected = 'file:///fo%C3%B2/b%C3%A4r/file.cpp'
+
+  let uri = ccls#uri#path2uri(path)
+
+  AssertEqual expected, uri
+
+
+Execute(Test ccls#uri#path2uri Windows):
+  call MockFunction(b:script, 'is_windows', {-> 1})
+  let path = 'C:\foò\bär\file.cpp'
+  let expected = 'file:///C:/fo%C3%B2/b%C3%A4r/file.cpp'
+
+  let uri = ccls#uri#path2uri(path)
+
+  AssertEqual expected, uri
+
+
+Execute(Test ccls#uri#path2uri Cygwin):
+  call MockFunction(b:script, 'is_windows', {-> 1})
+  call MockFunction(b:script, 'is_cygwin', {-> 1})
+  let path = '/c/foò/bär/file.cpp'
+  let expected = 'file:///C:/fo%C3%B2/b%C3%A4r/file.cpp'
+
+  let uri = ccls#uri#path2uri(path)
+
+  AssertEqual expected, uri
+
+
+Execute(Test ccls#uri#uri2path UNIX):
+  let uri = 'file:///fo%C3%B2/b%C3%A4r/file.cpp'
+  let expected = '/foò/bär/file.cpp'
+
+  let path = ccls#uri#uri2path(uri)
+
+  AssertEqual expected, path
+
+
+Execute(Test ccls#uri#uri2path Windows):
+  call MockFunction(b:script, 'is_windows', {-> 1})
+  let uri = 'file:///C:/fo%C3%B2/b%C3%A4r/file.cpp'
+  let expected = 'C:\foò\bär\file.cpp'
+
+  let path = ccls#uri#uri2path(uri)
+
+
+Execute(Test ccls#uri#uri2path Cygwin):
+  call MockFunction(b:script, 'is_windows', {-> 1})
+  call MockFunction(b:script, 'is_cygwin', {-> 1})
+  let uri = 'file:///C:/fo%C3%B2/b%C3%A4r/file.cpp'
+  let expected = '/c/foò/bär/file.cpp'
+
+  let path = ccls#uri#uri2path(uri)
+
+  AssertEqual expected, path

--- a/test/test_05_uri.vader
+++ b/test/test_05_uri.vader
@@ -59,7 +59,7 @@ Execute(Test ccls#uri#uri2path UNIX):
 Execute(Test ccls#uri#uri2path Windows):
   call MockFunction(b:script, 'is_windows', {-> 1})
   call MockFunction(b:script, 'is_cygwin', {-> 0})
-  let uri = 'file:///C:/fo%C3%B2/b%C3%A4r/file.cpp'
+  let uri = 'file:///C%3A/fo%C3%B2/b%C3%A4r/file.cpp'
   let expected = 'C:\foò\bär\file.cpp'
 
   let path = ccls#uri#uri2path(uri)
@@ -68,7 +68,7 @@ Execute(Test ccls#uri#uri2path Windows):
 Execute(Test ccls#uri#uri2path Cygwin):
   call MockFunction(b:script, 'is_windows', {-> 1})
   call MockFunction(b:script, 'is_cygwin', {-> 1})
-  let uri = 'file:///C:/fo%C3%B2/b%C3%A4r/file.cpp'
+  let uri = 'file:///C%3A/fo%C3%B2/b%C3%A4r/file.cpp'
   let expected = '/c/foò/bär/file.cpp'
 
   let path = ccls#uri#uri2path(uri)

--- a/test/test_05_uri.vader
+++ b/test/test_05_uri.vader
@@ -2,14 +2,19 @@ Before:
   let b:script = 'autoload/ccls/uri.vim'
 
   source test/utils.vim
-  source autoload/ccls/uri.vim
 
 
 After:
   unlet! b:script
 
 
+Execute(Setup):
+  source autoload/ccls/uri.vim
+
+
 Execute(Test ccls#uri#path2uri UNIX):
+  call MockFunction(b:script, 'is_windows', {-> 0})
+  call MockFunction(b:script, 'is_cygwin', {-> 0})
   let path = '/foò/bär/file.cpp'
   let expected = 'file:///fo%C3%B2/b%C3%A4r/file.cpp'
 
@@ -20,6 +25,7 @@ Execute(Test ccls#uri#path2uri UNIX):
 
 Execute(Test ccls#uri#path2uri Windows):
   call MockFunction(b:script, 'is_windows', {-> 1})
+  call MockFunction(b:script, 'is_cygwin', {-> 0})
   let path = 'C:\foò\bär\file.cpp'
   let expected = 'file:///C:/fo%C3%B2/b%C3%A4r/file.cpp'
 
@@ -40,6 +46,8 @@ Execute(Test ccls#uri#path2uri Cygwin):
 
 
 Execute(Test ccls#uri#uri2path UNIX):
+  call MockFunction(b:script, 'is_windows', {-> 0})
+  call MockFunction(b:script, 'is_cygwin', {-> 0})
   let uri = 'file:///fo%C3%B2/b%C3%A4r/file.cpp'
   let expected = '/foò/bär/file.cpp'
 
@@ -50,6 +58,7 @@ Execute(Test ccls#uri#uri2path UNIX):
 
 Execute(Test ccls#uri#uri2path Windows):
   call MockFunction(b:script, 'is_windows', {-> 1})
+  call MockFunction(b:script, 'is_cygwin', {-> 0})
   let uri = 'file:///C:/fo%C3%B2/b%C3%A4r/file.cpp'
   let expected = 'C:\foò\bär\file.cpp'
 

--- a/test/utils.vim
+++ b/test/utils.vim
@@ -6,17 +6,35 @@ function! s:get_scripts() abort
     return l:out
 endfunction
 
-" Get a (possibly local) function from a script
-function! GetFunction(script, name) abort
+" Get the name of a (possibly local) function from a script
+function! s:get_function_name(script, name) abort
     if match(s:get_scripts(), a:script) < 0
         exec 'source ' . a:script
     endif
     for l:line in split(s:get_scripts(), '\n')
         if match(l:line, a:script) >= 0
             let l:sid = str2nr(split(l:line, ': ')[0])
-            return function('<SNR>' . l:sid . '_' . a:name)
+            return '<SNR>' . l:sid . '_' . a:name
         endif
     endfor
+endfunction
+
+" Get a (possibly local) function from a script
+function! GetFunction(script, name) abort
+    return function(s:get_function_name(a:script, a:name))
+endfunction
+
+" Replace the implementation of a function with a mock
+function! MockFunction(script, name, mock) abort
+    let l:function_name = s:get_function_name(a:script, a:name)
+
+    let l:code = "
+    \\n    function! %s(...) abort closure
+    \\n        return call(a:mock, a:000)
+    \\n    endfunction
+    \"
+
+    execute printf(l:code, l:function_name)
 endfunction
 
 " Get a list of echoed messages


### PR DESCRIPTION
* Move URI conversion functions (path2uri and uri2path) to a new script
  located in autoload/ccls/uri.vim.
* Refactor implementation, fix native Windows path handling, and add
  Cygwin path handling.
* Add function mocking utility to test/utils.vim.
* Add unit test for Windows and Cygwin path handling.

Resolves #45 