### PR TITLE
Run test suites independently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   CODECOV_UPLOADER=codecov
 
 install:
+    - pip install --user 'click<8.0.0'
     - pip install --user covimerage==0.2.1
     - |
         curl -fLso "${CODECOV_UPLOADER}" https://codecov.io/bash;
@@ -27,7 +28,7 @@ script:
 after_success: |
     set -eo pipefail
     profile_file=$(ls | grep 'profile_file.*0\.4\.3')
-    python -m covimerage write_coverage "${profile_file}"
+    python -m covimerage write_coverage ${profile_file}
     sed -i "s,/testplugin/,$PWD/,g" .coverage_covimerage
     python -m covimerage -vv xml
     python -m covimerage report -m

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -26,29 +26,32 @@ exit_status=0
 
 # Run tests
 for vim in ${vim_binaries}; do
+    for test_suite in ./test/*.vader ; do
+        test_name=$(basename "${test_suite}" | cut -d'.' -f1)
 
-    # Collect profiling data if an output file name is provided
-    if [ "${profile_prefix}" != '' ]; then
-        profile_file="${profile_prefix}_${vim}"
-    fi
+        # Collect profiling data if an output file name is provided
+        if [ "${profile_prefix}" != '' ]; then
+            profile_file="${profile_prefix}_${vim}_${test_name}"
+        fi
 
-    find test -name '*.swp' -delete
+        find test -name '*.swp' -delete
 
-    docker run \
-        --rm \
-        -a stderr \
-        -e VADER_OUTPUT_FILE=/dev/stderr \
-        -e VIM_PROFILE_FILE="${profile_file}" \
-        -v "$PWD:/testplugin" \
-        -v "$PWD/test:/home"\
-        -w /testplugin \
-        "${docker_image}" \
-            "/vim-build/bin/${vim}" -u test/vimrc "+Vader! ./test/*.vader" 2>&1
+        docker run \
+            --rm \
+            -a stderr \
+            -e VADER_OUTPUT_FILE=/dev/stderr \
+            -e VIM_PROFILE_FILE="${profile_file}" \
+            -v "$PWD:/testplugin" \
+            -v "$PWD/test:/home"\
+            -w /testplugin \
+            "${docker_image}" \
+                "/vim-build/bin/${vim}" -u test/vimrc "+Vader! ${test_suite}" 2>&1
 
-    # shellcheck disable=SC2181
-    if [ "$?" -ne 0 ]; then
-        exit_status=1
-    fi
+        # shellcheck disable=SC2181
+        if [ "$?" -ne 0 ]; then
+            exit_status=1
+        fi
+    done
 done
 
 # Run vint

--- a/test/test_01_lsp.vader
+++ b/test/test_01_lsp.vader
@@ -29,10 +29,39 @@ Before:
 
   messages clear
 
+
 After:
   unlet! b:script
   unlet! mock_handler
   unlet! Function
+
+
+Execute(Test ccls#lsp#request with no LSP client):
+  call ccls#lsp#request('bufnr', 'method', 'params', mock_handler.function)
+
+  AssertEqual 0, mock_handler.count
+  AssertMessage 'vim-ccls: No LSP plugin found!'
+
+
+Execute(Test ccls#lsp#request with vim-lsp and ccls server unavailable):
+  source test/mock/lsp.vim
+  let g:mock_lsp_server_names = ['some_server', 'some_other_server']
+
+  call ccls#lsp#request('bufnr', 'method', 'params', mock_handler.function)
+
+  AssertEqual 0, mock_handler.count
+  AssertMessage 'vim-ccls: ccls language server unvailable'
+
+
+Execute(Test ccls#lsp#request with ALE throwing an exception):
+  source test/mock/ale/lsp_linter.vim
+  let g:mock_ale_fail = 1
+
+  call ccls#lsp#request('bufnr', 'method', 'params', mock_handler.function)
+
+  AssertEqual 0, mock_handler.count
+  AssertMessage 'vim-ccls: LSP error'
+
 
 Execute(Test s:ale_handler error handling):
   let Function = GetFunction(b:script, 'ale_handler')
@@ -131,30 +160,3 @@ Execute(Test s:coc_handler error handling):
   AssertEqual 1, mock_handler.count
   AssertEqual 'mock_result', mock_handler.args[0][0]
   AssertNoMessage 'vim-ccls: LSP error'
-
-
-Execute(Test ccls#lsp#request with no LSP client):
-  call ccls#lsp#request('bufnr', 'method', 'params', mock_handler.function)
-
-  AssertEqual 0, mock_handler.count
-  AssertMessage 'vim-ccls: No LSP plugin found!'
-
-
-Execute(Test ccls#lsp#request with vim-lsp and ccls server unavailable):
-  source test/mock/lsp.vim
-  let g:mock_lsp_server_names = ['some_server', 'some_other_server']
-
-  call ccls#lsp#request('bufnr', 'method', 'params', mock_handler.function)
-
-  AssertEqual 0, mock_handler.count
-  AssertMessage 'vim-ccls: ccls language server unvailable'
-
-
-Execute(Test ccls#lsp#request with ALE throwing an exception):
-  source test/mock/ale/lsp_linter.vim
-  let g:mock_ale_fail = 1
-
-  call ccls#lsp#request('bufnr', 'method', 'params', mock_handler.function)
-
-  AssertEqual 0, mock_handler.count
-  AssertMessage 'vim-ccls: LSP error'

--- a/test/test_02_syntax.vader
+++ b/test/test_02_syntax.vader
@@ -1,4 +1,5 @@
 Before:
+  source test/utils.vim
   syntax clear
 
 Execute(Test ccls#syntax#additional):

--- a/test/test_03_util.vader
+++ b/test/test_03_util.vader
@@ -1,4 +1,5 @@
 Before:
+  source test/utils.vim
   let b:tmp_dir = has('win32') ? expand('%TEMP%\') : '/tmp/'
   let b:ccls_log_file = b:tmp_dir . 'vim_ccls.log'
   let b:warning_text = 'This is a warning'


### PR DESCRIPTION
Run each test suite separately. This prevents from erasing profiling
(and therefore coverage) information from previous suites when a script
is sourced by another test suite.