### PR TITLE
gAdd global var g:yggdrasil_tree_filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ let g:ccls_float_width = 50
 let g:ccls_float_height = 20
 ```
 
+The tree buffer can have exclusion patterns to filter out nodes. Example below  
+will exclude all qt and std internal functions:
+```vim
+let g:yggdrasil_tree_filter = 'Q[A-Z].*\\|std::.*'
+```
+
 The following `<Plug>` mappings are available to interact with a tree buffer:
 ```
 <Plug>(yggdrasil-toggle-node)

--- a/autoload/ccls/yggdrasil/tree.vim
+++ b/autoload/ccls/yggdrasil/tree.vim
@@ -13,7 +13,7 @@ scriptencoding utf-8
 
 " Callback to retrieve the tree item representation of an object.
 function! s:node_get_tree_item_cb(node, object, status, tree_item) abort
-    if a:status ==? 'success'
+    if a:status ==? 'success' && (empty(g:yggdrasil_tree_filter) || a:object.name !~ g:yggdrasil_tree_filter)
         let l:new_node = s:node_new(a:node.tree, a:object, a:tree_item, a:node)
         call add(a:node.children, l:new_node)
         call s:tree_render(l:new_node.tree)
@@ -132,7 +132,7 @@ endfunction
 " equal to 'success', the root node is set and the tree view is updated
 " accordingly, otherwise nothing happens.
 function! s:tree_set_root_cb(tree, object, status, tree_item) abort
-    if a:status ==? 'success'
+    if a:status ==? 'success' && (empty(g:yggdrasil_tree_filter) || a:object.name !~ g:yggdrasil_tree_filter)
         let a:tree.maxid = -1
         let a:tree.root = s:node_new(a:tree, a:object, a:tree_item, {})
         call s:tree_render(a:tree)
@@ -292,3 +292,4 @@ function! ccls#yggdrasil#tree#new(provider) abort
 
     call b:yggdrasil_tree.update()
 endfunction
+

--- a/plugin/ccls.vim
+++ b/plugin/ccls.vim
@@ -35,6 +35,10 @@ if !exists('g:ccls_quiet')
     let g:ccls_quiet = 0
 endif
 
+if !exists('g:yggdrasil_tree_filter')
+    let g:yggdrasil_tree_filter = ''
+endif
+
 command! CclsVars                      call ccls#messages#vars()
 
 command! CclsMembers                   call ccls#messages#members({})
@@ -56,3 +60,4 @@ command! CclsCallees                   call ccls#messages#calls(v:true)
 
 command! -nargs=* CclsCallHierarchy    call ccls#messages#call_hierarchy(v:false, <f-args>)
 command! -nargs=* CclsCalleeHierarchy  call ccls#messages#call_hierarchy(v:true, <f-args>)
+


### PR DESCRIPTION
This is string variable that store the regex for excluding item from yggdrasil-tree.

Example below is to always exclude all item from std:: library and Qt internal classes.

{
    "firman199x/vim-ccls",
        init = function()
            vim.g.yggdrasil_tree_filter = 'Q[A-Z].*\\|std::.*'
        end,
}
![vim-ccls](https://github.com/m-pilia/vim-ccls/assets/50283295/0f7b62e8-545c-4ba3-8023-186ee70b2994)
